### PR TITLE
[17.0] sale_expense: Include security folder on __manifest__.py

### DIFF
--- a/addons/sale_expense/__manifest__.py
+++ b/addons/sale_expense/__manifest__.py
@@ -15,6 +15,8 @@ This module allow to reinvoice employee expense, by setting the SO directly on t
 """,
     'depends': ['sale_management', 'hr_expense'],
     'data': [
+        'security/ir.model.access.csv',
+        'security/sale_expense_security.xml',
         'data/sale_expense_data.xml',
         'views/product_view.xml',
         'views/hr_expense_views.xml',


### PR DESCRIPTION
Security folder on sale_expense was not included in manifest,  I add it.

Description of the issue/feature this PR addresses: sale_order_rule_expense_user not found

Current behavior before PR:

Desired behavior after PR is merged: sale_order_rule_expense_user so can handle a rule for user to write and then not see sales on sale state




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
